### PR TITLE
Remove unecessary logging

### DIFF
--- a/mcdowellcv.cls
+++ b/mcdowellcv.cls
@@ -162,7 +162,6 @@ Ligatures={TeX, NoCommon, NoDiscretionary}]{\mainfontface}
 \name{}
 
 \newcommand\printname{
-  \typeout {kokoko}
   \typeout \spaceskip
   \spaceskip \namespaceskip \relax
   \textbf{\LARGE\textls[110]{\textsc{\@name}}}


### PR DESCRIPTION
Stop printing out "kokoko" in the terminal when defining a name.